### PR TITLE
Ignore IntelliJ IDE-oriented files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ target/
 .sync
 syncano.yml
 scripts
+*.iml
+


### PR DESCRIPTION
IntelliJ creates files with extension .iml and keeps there IDE-oriented configuration of project's modules. I think that these files should be ignored via .gitignore.

This is proper the version of pull request #30. In #30 I accidentally forked wrong branch and pull request contained too many commits.
